### PR TITLE
Remove polyfill.io link due to supply chain attack vulnerability

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,6 @@ extra_css:
 extra_javascript:
   - javascripts/mathjax.js
   - javascripts/analytics.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 copyright: Copyright &copy; 2023 Jason Liu


### PR DESCRIPTION
This commit replaces the reference to polyfill.io from the codebase and replaces it with one from cloudflare.com in response to the recent security incident involving malicious code injection.

See https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack for more details.